### PR TITLE
add sync-ssh-secret command

### DIFF
--- a/examples/rsync/db-example.md
+++ b/examples/rsync/db-example.md
@@ -37,15 +37,13 @@ $ ./scribe new-source --address ${address} --source-namespace source --source-co
 I0302 09:45:19.026520 4181483 options.go:305] ReplicationSource source-scribe-source created in namespace source
 ```
 
-TODO: add this to scribe CLI
-### Obtain an SSH secret from the destination namespace 
+### Sync an SSH secret from the destination namespace to the source namespace
+
+This assumes the default secret name that is created by the scribe controller. You can also pass `--ssh-keys-secret`
+that is a valid ssh-key-secret in the DestinationReplication namespace and cluster.
 
 ```console
-$ kubectl get secret -n dest scribe-rsync-dest-src-dest-scribe-destination -o yaml > /tmp/secret.yaml
-$ vi /tmp/secret.yaml
-# ^^^ change the namespace to "source"
-# ^^^ remove the owner reference (.metadata.ownerReferences)
-$ kubectl apply -f /tmp/secret.yaml
+scribe sync-ssh-secret --dest-namespace dest --source-namespace source
 ```
 
 TODO: add this to scribe CLI

--- a/examples/rsync/multi-context-sync.md
+++ b/examples/rsync/multi-context-sync.md
@@ -68,15 +68,17 @@ $ scribe new-source \
 I0302 09:45:19.026520 4181483 options.go:305] ReplicationSource source-scribe-source created in namespace source
 ```
 
-TODO: add this to scribe CLI
-### Obtain an SSH secret from the destination namespace 
+### Sync an SSH secret from the destination namespace to the source namespace
+
+This assumes the default secret name that is created by the scribe controller. You can also pass `--ssh-keys-secret`
+that is a valid ssh-key-secret in the DestinationReplication namespace and cluster.
 
 ```console
-$ kubectl --context kind-kind get secret -n dest scribe-rsync-dest-src-dest-scribe-destination -o yaml > /tmp/secret.yaml
-$ vi /tmp/secret.yaml
-# ^^^ change the namespace to "source"
-# ^^^ remove the owner reference (.metadata.ownerReferences)
-$ kubectl --context admin apply -f /tmp/secret.yaml
+scribe sync-ssh-secret \
+     --dest-namespace dest \
+     --dest-kube-clustername kind-kind --dest-kube-context kind-kind \
+     --source-namespace source \
+     --source-kube-clustername test034 --source-kube-context admin
 ```
 
 TODO: add this to scribe CLI

--- a/pkg/cmd/destination.go
+++ b/pkg/cmd/destination.go
@@ -51,8 +51,6 @@ func NewCmdScribeNewDestination(streams genericclioptions.IOStreams) *cobra.Comm
 	flags.StringVar(&o.AccessMode, "dest-access-mode", o.AccessMode, "the access modes for the destination volume. Must be provided if --dest-pvc is not provided; One of 'ReadWriteOnce|ReadOnlyMany|ReadWriteMany")
 	flags.StringVar(&o.VolumeSnapshotClassName, "dest-volume-snapshot-class", o.VolumeSnapshotClassName, "name of the VolumeSnapshotClass to be used for the destination volume, only if the copyMethod is 'Snapshot'. If not set, the default VSC will be used.")
 	flags.StringVar(&o.PVC, "dest-pvc", o.PVC, "name of an existing PVC to use as the transfer destination volume instead of automatically provisioning one.")
-	flags.StringVar(&o.Namespace, "dest-namespace", o.Namespace, "the transfer destination namespace. This namespace must exist. If not set, the ReplicationDestination will be created in the current namespace.")
-	// TODO: Default?
 	flags.StringVar(&o.Schedule, "dest-cron-spec", o.Schedule, "cronspec to be used to schedule replication to occur at regular, time-based intervals. If not set replication will be continuous.")
 	// TODO: should this be exposed?
 	flags.StringVar(&o.SSHKeys, "dest-ssh-keys", o.SSHKeys, "name of a secret in the destination namespace to be used for authentication. If not set, SSH keys will be generated and a secret will be created with the appropriate keys.")

--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -10,19 +10,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/klog/v2"
-	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type ReplicationOptions struct {
 	scribeOptions           scribeOptions
 	Mode                    string
-	KubeContext             string
-	DestinationClient       client.Client
-	SourceClient            client.Client
 	CopyMethod              string //v1alpha1.CopyMethodType
 	Capacity                string //*resource.Quantity
 	StorageClassName        string
@@ -67,59 +61,16 @@ func NewReplicationOptions(streams genericclioptions.IOStreams) *ReplicationOpti
 	}
 }
 
-// Complete takes the factory and infers options.
 func (o *ReplicationOptions) Complete(cmd *cobra.Command) error {
-	destKubeConfigFlags := genericclioptions.NewConfigFlags(true)
-	if len(o.scribeOptions.destKubeContext) > 0 {
-		destKubeConfigFlags.Context = &o.scribeOptions.destKubeContext
-	}
-	if len(o.scribeOptions.destKubeClusterName) > 0 {
-		destKubeConfigFlags.ClusterName = &o.scribeOptions.destKubeClusterName
-	}
-	sourceKubeConfigFlags := genericclioptions.NewConfigFlags(true)
-	if len(o.scribeOptions.sourceKubeContext) > 0 {
-		sourceKubeConfigFlags.Context = &o.scribeOptions.sourceKubeContext
-	}
-	if len(o.scribeOptions.sourceKubeClusterName) > 0 {
-		sourceKubeConfigFlags.ClusterName = &o.scribeOptions.sourceKubeClusterName
-	}
-	destf := kcmdutil.NewFactory(destKubeConfigFlags)
-	sourcef := kcmdutil.NewFactory(sourceKubeConfigFlags)
-
-	// get client and namespace
-	destClientConfig, err := destf.ToRESTConfig()
+	err := o.scribeOptions.Complete()
 	if err != nil {
 		return err
 	}
-	sourceClientConfig, err := sourcef.ToRESTConfig()
-	if err != nil {
-		return err
-	}
-	scheme := runtime.NewScheme()
-	scribev1alpha1.AddToScheme(scheme)
-	destKclient, err := client.New(destClientConfig, client.Options{Scheme: scheme})
-	if err != nil {
-		return err
-	}
-	o.DestinationClient = destKclient
-	sourceKclient, err := client.New(sourceClientConfig, client.Options{Scheme: scheme})
-	if err != nil {
-		return err
-	}
-	o.SourceClient = sourceKclient
-	if len(o.Namespace) == 0 {
-		switch o.Mode {
-		case "destination":
-			o.Namespace, _, err = destf.ToRawKubeConfigLoader().Namespace()
-			if err != nil {
-				return err
-			}
-		case "source":
-			o.Namespace, _, err = sourcef.ToRawKubeConfigLoader().Namespace()
-			if err != nil {
-				return err
-			}
-		}
+	switch o.Mode {
+	case "destination":
+		o.Namespace = o.scribeOptions.destNamespace
+	case "source":
+		o.Namespace = o.scribeOptions.sourceNamespace
 	}
 	if len(o.Name) == 0 {
 		o.Name = o.Namespace + "-scribe-" + o.Mode
@@ -279,7 +230,7 @@ func (o *ReplicationOptions) CreateReplicationDestination() error {
 			External: externalSpec,
 		},
 	}
-	if err := o.DestinationClient.Create(context.TODO(), rd); err != nil {
+	if err := o.scribeOptions.DestinationClient.Create(context.TODO(), rd); err != nil {
 		return err
 	}
 	klog.V(0).Infof("ReplicationDestination %s created in namespace %s", o.Name, o.Namespace)
@@ -288,8 +239,6 @@ func (o *ReplicationOptions) CreateReplicationDestination() error {
 
 // CreateReplicationSource creates a ReplicationSource resource
 func (o *ReplicationOptions) CreateReplicationSource() error {
-	klog.Infof("O.DESTCLIENT: %v", o.DestinationClient)
-	klog.Infof("O.SOURCECLIENT: %v", o.SourceClient)
 	c, err := o.getCommonOptions()
 	if err != nil {
 		return err
@@ -338,7 +287,7 @@ func (o *ReplicationOptions) CreateReplicationSource() error {
 			External:  externalSpec,
 		},
 	}
-	if err := o.SourceClient.Create(context.TODO(), rs); err != nil {
+	if err := o.scribeOptions.SourceClient.Create(context.TODO(), rs); err != nil {
 		return err
 	}
 	klog.V(0).Infof("ReplicationSource %s created in namespace %s", o.Name, o.Namespace)

--- a/pkg/cmd/source.go
+++ b/pkg/cmd/source.go
@@ -51,7 +51,6 @@ func NewCmdScribeNewSource(streams genericclioptions.IOStreams) *cobra.Command {
 	flags.StringVar(&o.AccessMode, "source-access-mode", o.AccessMode, "provided to override the accessModes of the point-in-Time image. One of 'ReadWriteOnce|ReadOnlyMany|ReadWriteMany")
 	flags.StringVar(&o.VolumeSnapshotClassName, "source-volume-snapshot-class", o.VolumeSnapshotClassName, "name of the VolumeSnapshotClass to be used for the source volume, only if the copyMethod is 'Snapshot'. If not set, the default VSC will be used.")
 	flags.StringVar(&o.PVC, "source-pvc", o.PVC, "name of an existing PersistentVolumeClaim (PVC) to replicate.")
-	flags.StringVar(&o.Namespace, "source-namespace", o.Namespace, "the transfer source namespace. This namespace must exist.")
 	// TODO: Default to every 3min for source?
 	flags.StringVar(&o.Schedule, "source-cron-spec", "*/3 * * * *", "cronspec to be used to schedule capturing the state of the source volume. If not set the source volume will be captured every 3 minutes.")
 	// TODO: should this be exposed?

--- a/pkg/cmd/sync_secret.go
+++ b/pkg/cmd/sync_secret.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	scribev1alpha1 "github.com/backube/scribe/api/v1alpha1"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/klog/v2"
+	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	scribeSyncSSHSecretLong = templates.LongDesc(`
+Scribe is a command line tool for a scribe operator running in a Kubernetes cluster. Scribe asynchronously replicates Kubernetes persistent volumes between clusters or namespaces using rsync, rclone, or restic. Scribe uses a ReplicationDestination and a ReplicationSource to replicate a volume. Data will be synced according to the configured sync schedule.
+`)
+	scribeSyncSSHSecretExample = templates.Examples(`
+	# Copy the SSH secret from the ReplicationDestination namespace to the ReplicationSource namespace.
+	# Secret will be copied from namespace 'dest' to namespace 'source'.
+    scribe sync-ssh-secret --dest-namespace=dest --source-namespace=source
+
+	# Copy the SSH secret from the ReplicationDestination namespace in one cluster 
+	# to the ReplicationSource namespace in another clutser.
+	# Secret will be copied from clustername 'kind-kind' context 'kind-kind' namespace 'dest'
+	# to context 'admin' clustername 'api-test-com:6443' namespace 'source'.
+    scribe sync-ssh-secret --dest-namespace=dest --source-namespace=source \
+			--dest-kube-context=kind-kind --dest-clustername=kind-kind \
+			--source-kube-context=admin --source-clustername=api-test-com:6443
+    `)
+)
+
+type sshKeysSecretOptions struct {
+	scribeOptions scribeOptions
+	SSHKeysSecret string
+
+	genericclioptions.IOStreams
+}
+
+func NewCmdScribeSyncSSHSecret(streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewSSHKeysSecretOptions(streams)
+	cmd := &cobra.Command{
+		Use:     "sync-ssh-secret [OPTIONS]",
+		Short:   i18n.T("Copy the SSH secret for rsync between namespaces and/or clusters."),
+		Long:    fmt.Sprintf(scribeSyncSSHSecretLong),
+		Example: fmt.Sprintf(scribeSyncSSHSecretExample),
+		Run: func(cmd *cobra.Command, args []string) {
+			kcmdutil.CheckErr(o.Complete(cmd))
+			//TODO: kcmdutil.CheckErr(o.Validate())
+			kcmdutil.CheckErr(o.SyncSSHSecret())
+		},
+	}
+	flags := cmd.Flags()
+	o.scribeOptions.Bind(flags)
+	flags.StringVar(&o.SSHKeysSecret, "ssh-keys-secret", o.SSHKeysSecret, "name of an existing valid SSHKeys secret to be used for authentication. If not set, the default SSHKey secret-name will be used from the ReplicationDestination location (default '<scribe-rsync->dest-src-<name-of-replication-destination>)'.")
+
+	return cmd
+}
+
+func NewSSHKeysSecretOptions(streams genericclioptions.IOStreams) *sshKeysSecretOptions {
+	return &sshKeysSecretOptions{
+		IOStreams: streams,
+	}
+}
+
+// Complete takes the cmd and infers options.
+func (o *sshKeysSecretOptions) Complete(cmd *cobra.Command) error {
+	ctx := context.Background()
+	err := o.scribeOptions.Complete()
+	if err != nil {
+		return err
+	}
+	repDests := &scribev1alpha1.ReplicationDestinationList{}
+	opts := []client.ListOption{
+		client.InNamespace(o.scribeOptions.destNamespace),
+	}
+
+	err = o.scribeOptions.DestinationClient.List(ctx, repDests, opts...)
+	if err != nil {
+		return err
+	}
+
+	if len(o.SSHKeysSecret) == 0 {
+		o.SSHKeysSecret = "scribe-rsync-dest-src-" + repDests.Items[0].Name
+	}
+	return nil
+}
+
+func (o *sshKeysSecretOptions) SyncSSHSecret() error {
+	ctx := context.Background()
+	originalSecret := &corev1.Secret{}
+	nsName := types.NamespacedName{
+		Namespace: o.scribeOptions.destNamespace,
+		Name:      o.SSHKeysSecret,
+	}
+	err := o.scribeOptions.DestinationClient.Get(ctx, nsName, originalSecret)
+	if err != nil {
+		return err
+	}
+	newSecret := originalSecret.DeepCopy()
+	newSecret.ObjectMeta = metav1.ObjectMeta{
+		Name:            originalSecret.ObjectMeta.Name,
+		Namespace:       o.scribeOptions.sourceNamespace,
+		OwnerReferences: nil,
+	}
+
+	err = o.scribeOptions.SourceClient.Create(ctx, newSecret)
+	if err != nil {
+		return err
+	}
+	klog.Infof("secret %s created in namespace %s", o.SSHKeysSecret, o.scribeOptions.sourceNamespace)
+	return nil
+}


### PR DESCRIPTION
This commit adds a `scribe sync-ssh-secret` command, to sync an SSHKeys secret from ReplicationDestination namespace & cluster to a ReplicationSource destination & cluster.